### PR TITLE
Using `file-split` package instead of native `split` command for file splitting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,6 @@ We're currently working on adding support for adding custom dependencies to the 
 
 Stay tuned to updates on the [issue](https://github.com/mazlix/meteor-now/issues/6)
 
-### Does this work with windows?
-Currently `meteor-now` does **NOT** support windows.
-
 # Authors
 <a href="https://www.github.com/mazlix"><img src="https://avatars2.githubusercontent.com/u/519731?v=3&s=460" alt="Justin Avatar" height="100" width="100"></a>|<a href="https://www.github.com/purplecones"><img src="https://avatars1.githubusercontent.com/u/136654?v=3&s=460" height="100" width="100" alt="Mirza Avatar"></a>
 ---|---

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "babel-polyfill": "^6.22.0",
     "cli-spinners": "^1.0.0",
     "colors": "^1.1.2",
+    "delete": "^0.3.2",
     "minimist": "^1.2.0",
     "ora": "^1.0.0",
     "promise-spawner": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "colors": "^1.1.2",
     "minimist": "^1.2.0",
     "ora": "^1.0.0",
-    "promise-spawner": "^1.1.3"
+    "promise-spawner": "^1.1.3",
+    "split-file": "^1.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.21.0",

--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,7 @@
 import 'babel-polyfill';
 import colors from 'colors';
 import splitFile from 'split-file';
+import del from 'delete';
 import spinner from './spinner';
 import Command from './command';
 import logger from './logger';
@@ -82,8 +83,7 @@ const deployMeteorApp = async () => {
 
 const cleanup = async () => {
   logger('cleaning up');
-  const splitCommand = new Command('rm .meteor/local/builds/*');
-  await splitCommand.run();
+  await del.promise(['.meteor/local/builds/*']);
 };
 
 const prepareForUpload = async () => {

--- a/src/app.js
+++ b/src/app.js
@@ -32,7 +32,7 @@ const createSupervisorFile = async () => {
 
 const splitBuild = async () => {
   logger('splitting bundle');
-  await new Promise(function(resolve, reject) {
+  await new Promise((resolve, reject) => {
     splitFile.splitFileBySize(`.meteor/local/builds/${dockerfile.buildzip}`, 999999, (err, names) => {
       if (err) {
         reject(err);

--- a/src/app.js
+++ b/src/app.js
@@ -34,10 +34,12 @@ const createSupervisorFile = async () => {
 const splitBuild = async () => {
   logger('splitting bundle');
   await new Promise((resolve, reject) => {
-    splitFile.splitFileBySize(`.meteor/local/builds/${dockerfile.buildzip}`, 999999, (err, names) => {
+    splitFile.splitFileBySize(`.meteor/local/builds/${dockerfile.buildzip}`, 999999, async (err, names) => {
       if (err) {
         reject(err);
       }
+      // delete original bundle file so that it doesnt get uploaded to now
+      await del.promise([`.meteor/local/builds/${dockerfile.buildzip}`]);
       resolve(names);
     });
   });

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 // required for async/await to work
 import 'babel-polyfill';
 import colors from 'colors';
+import splitFile from 'split-file';
 import spinner from './spinner';
 import Command from './command';
 import logger from './logger';
@@ -31,8 +32,14 @@ const createSupervisorFile = async () => {
 
 const splitBuild = async () => {
   logger('splitting bundle');
-  const splitCommand = new Command(`split -b 999999 .meteor/local/builds/${dockerfile.buildzip} .meteor/local/builds/x && rm .meteor/local/builds/${dockerfile.buildzip}`);
-  await splitCommand.run();
+  await new Promise(function(resolve, reject) {
+    splitFile.splitFileBySize(`.meteor/local/builds/${dockerfile.buildzip}`, 999999, (err, names) => {
+      if (err) {
+        reject(err);
+      }
+      resolve(names);
+    });
+  });
 };
 
 const handleMeteorSettings = async () => {
@@ -75,7 +82,7 @@ const deployMeteorApp = async () => {
 
 const cleanup = async () => {
   logger('cleaning up');
-  const splitCommand = new Command('rm .meteor/local/builds/x* .meteor/local/builds/Dockerfile');
+  const splitCommand = new Command('rm .meteor/local/builds/*');
   await splitCommand.run();
 };
 

--- a/src/dockerfile.js
+++ b/src/dockerfile.js
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import { getDependencies } from './utils';
 
+const isWin = /^win/.test(process.platform);
+
 class Dockerfile {
   constructor() {
     // Set node to correct version based on meteor version (1.4+ vs 1.3-)
@@ -21,7 +23,11 @@ class Dockerfile {
 
     // Determine bundle name (it's based on meteor directory)
     const cwd = process.cwd();
-    this.builddir = cwd.split('/')[cwd.split('/').length - 1];
+    if (isWin) {
+      this.builddir = cwd.split('\\')[cwd.split('\\').length - 1];
+    } else {
+      this.builddir = cwd.split('/')[cwd.split('/').length - 1];
+    }
     this.buildzip = `${this.builddir}.tar.gz`;
   }
 
@@ -43,7 +49,7 @@ ${dependencies}
 ENV NPM_CONFIG_LOGLEVEL warn
 LABEL name="${this.builddir}"
 COPY . .
-RUN cat x* > bundle.tar.gz
+RUN cat *tar.gz* > bundle.tar.gz
 RUN tar -xzf bundle.tar.gz
 WORKDIR bundle/programs/server
 RUN npm install
@@ -65,7 +71,7 @@ ENV NPM_CONFIG_LOGLEVEL warn
 LABEL name="${this.builddir}"
 COPY . /usr/src/app/
 WORKDIR /usr/src/app
-RUN cat x* > bundle.tar.gz
+RUN cat *tar.gz* > bundle.tar.gz
 RUN tar -xzf bundle.tar.gz
 WORKDIR bundle/programs/server
 RUN npm install

--- a/src/dockerfile.js
+++ b/src/dockerfile.js
@@ -49,7 +49,7 @@ ${dependencies}
 ENV NPM_CONFIG_LOGLEVEL warn
 LABEL name="${this.builddir}"
 COPY . .
-RUN cat *tar.gz* > bundle.tar.gz
+RUN cat *sf-part* > bundle.tar.gz
 RUN tar -xzf bundle.tar.gz
 WORKDIR bundle/programs/server
 RUN npm install
@@ -71,7 +71,7 @@ ENV NPM_CONFIG_LOGLEVEL warn
 LABEL name="${this.builddir}"
 COPY . /usr/src/app/
 WORKDIR /usr/src/app
-RUN cat *tar.gz* > bundle.tar.gz
+RUN cat *sf-part* > bundle.tar.gz
 RUN tar -xzf bundle.tar.gz
 WORKDIR bundle/programs/server
 RUN npm install

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,6 +113,10 @@ arr-flatten@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.1.tgz#e5ffe54d45e19f32f216e91eb99c8ce892bb604b"
 
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
+
 array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
@@ -160,6 +164,10 @@ assert@^1.1.1:
   dependencies:
     util "0.10.3"
 
+async-array-reduce@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/async-array-reduce/-/async-array-reduce-0.2.1.tgz#c8be010a2b5cd00dea96c81116034693dfdd82d1"
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -168,7 +176,7 @@ async@^0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
 
-async@^1.3.0, async@^1.4.0, async@^1.4.2:
+async@^1.3.0, async@^1.4.0, async@^1.4.2, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
@@ -920,6 +928,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird@^3.3.5:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
+
 bluebird@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-1.2.4.tgz#5985ec23cb6ff1a5834cc6447b3c5ef010fd321a"
@@ -1299,6 +1311,17 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
+delete@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/delete/-/delete-0.3.2.tgz#7cfecf5ef7dfb802fad27ab8f5be5ae546c5b79e"
+  dependencies:
+    async "^1.5.2"
+    bluebird "^3.3.5"
+    extend-shallow "^2.0.1"
+    lazy-cache "^1.0.4"
+    matched "^0.4.1"
+    rimraf "^2.5.2"
+
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
@@ -1613,6 +1636,18 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+expand-tilde@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-1.2.2.tgz#0b81eba897e5a3d31d1c3d102f8f01441e559449"
+  dependencies:
+    os-homedir "^1.0.1"
+
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
+
 extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
@@ -1722,6 +1757,10 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+fs-exists-sync@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1823,6 +1862,22 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-modules@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-0.2.3.tgz#ea5a3bed42c6d6ce995a4f8a1269b5dae223828d"
+  dependencies:
+    global-prefix "^0.1.4"
+    is-windows "^0.2.0"
+
+global-prefix@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
+  dependencies:
+    homedir-polyfill "^1.0.0"
+    ini "^1.3.4"
+    is-windows "^0.2.0"
+    which "^1.2.12"
+
 globals@^9.0.0, globals@^9.14.0:
   version "9.14.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.14.0.tgz#8859936af0038741263053b39d0e76ca241e4034"
@@ -1883,6 +1938,12 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-glob@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/has-glob/-/has-glob-0.1.1.tgz#a261c4c2a6c667e0c77b700a7f297c39ef3aa589"
+  dependencies:
+    is-glob "^2.0.1"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -1912,6 +1973,12 @@ home-or-tmp@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
+
+homedir-polyfill@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
+  dependencies:
+    parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4:
   version "2.1.5"
@@ -1974,7 +2041,7 @@ inherits@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
-ini@~1.3.0:
+ini@^1.3.4, ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
@@ -2058,7 +2125,7 @@ is-equal-shallow@^0.1.3:
   dependencies:
     is-primitive "^2.0.0"
 
-is-extendable@^0.1.1:
+is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
 
@@ -2152,6 +2219,14 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-valid-glob@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-0.3.0.tgz#d4b55c69f51886f9b65c70d6c2622d37e29f48fe"
+
+is-windows@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -2530,9 +2605,15 @@ kind-of@^3.0.2:
   dependencies:
     is-buffer "^1.0.2"
 
-lazy-cache@^1.0.3:
+lazy-cache@^1.0.3, lazy-cache@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
+
+lazy-cache@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-2.0.2.tgz#b9190a4f913354694840859f8a8f7084d8822264"
+  dependencies:
+    set-getter "^0.1.0"
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -2694,6 +2775,20 @@ marked-terminal@^1.6.2:
 marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
+
+matched@^0.4.1:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/matched/-/matched-0.4.4.tgz#56d7b7eb18033f0cf9bc52eb2090fac7dc1e89fa"
+  dependencies:
+    arr-union "^3.1.0"
+    async-array-reduce "^0.2.0"
+    extend-shallow "^2.0.1"
+    fs-exists-sync "^0.1.0"
+    glob "^7.0.5"
+    has-glob "^0.1.1"
+    is-valid-glob "^0.3.0"
+    lazy-cache "^2.0.1"
+    resolve-dir "^0.1.0"
 
 memory-fs@^0.2.0:
   version "0.2.0"
@@ -2974,7 +3069,7 @@ os-browserify@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f"
 
-os-homedir@^1.0.0:
+os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
@@ -3006,6 +3101,10 @@ parse-json@^2.2.0:
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
     error-ex "^1.2.0"
+
+parse-passwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
 
 parse5@^1.5.1:
   version "1.5.1"
@@ -3324,6 +3423,13 @@ require-uncached@^1.0.2:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+resolve-dir@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"
+  dependencies:
+    expand-tilde "^1.2.2"
+    global-modules "^0.2.3"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
@@ -3356,7 +3462,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@~2.5.1, rimraf@~2.5.4:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.2, rimraf@~2.5.1, rimraf@~2.5.4:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:
@@ -3398,6 +3504,12 @@ sax@^1.1.4:
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
+set-getter@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.0.tgz#d769c182c9d5a51f409145f2fba82e5e86e80376"
+  dependencies:
+    to-object-path "^0.3.0"
 
 set-immediate-shim@^1.0.1:
   version "1.0.1"
@@ -3675,6 +3787,12 @@ to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
 
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  dependencies:
+    kind-of "^3.0.2"
+
 tough-cookie@^2.3.1, tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
@@ -3840,7 +3958,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.0.5, which@^1.1.1:
+which@^1.0.5, which@^1.1.1, which@^1.2.12:
   version "1.2.12"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz#de67b5e450269f194909ef23ece4ebe416fa1192"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -172,7 +172,7 @@ async@^1.3.0, async@^1.4.0, async@^1.4.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.4:
+async@^2.1.2, async@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.1.4.tgz#2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4"
   dependencies:
@@ -3480,6 +3480,12 @@ spdx-expression-parse@~1.0.0:
 spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
+
+split-file@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/split-file/-/split-file-1.2.0.tgz#fa759f2ebe450e81d4b1631ff888b9a05d79e75b"
+  dependencies:
+    async "^2.1.2"
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
Fixes https://github.com/mazlix/meteor-now/issues/28