### PR TITLE
fix #34

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cli-spinners": "^1.0.0",
     "colors": "^1.1.2",
     "delete": "^0.3.2",
+    "lodash": "^4.17.4",
     "minimist": "^1.2.0",
     "now-client": "^0.7.0",
     "ora": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "colors": "^1.1.2",
     "delete": "^0.3.2",
     "minimist": "^1.2.0",
+    "now-client": "^0.7.0",
     "ora": "^1.0.0",
     "promise-spawner": "^1.1.3",
     "split-file": "2.0.0-alpha.1"

--- a/src/app.js
+++ b/src/app.js
@@ -90,7 +90,7 @@ const getDeploymentUrl = async () => {
   try {
     deployments = await now.getDeployments();
   } catch (err) {
-    console.error(err);
+    console.error(err); // eslint-disable-line no-console
   }
   // get latest deployment url from the list
   const sortedDeployments = _.sortBy(deployments, 'created');

--- a/src/app.js
+++ b/src/app.js
@@ -1,8 +1,10 @@
 // required for async/await to work
 import 'babel-polyfill';
 import colors from 'colors';
+import _ from 'lodash';
 import splitFile from 'split-file';
 import del from 'delete';
+import nowClient from 'now-client';
 import spinner from './spinner';
 import Command from './command';
 import logger from './logger';
@@ -77,10 +79,22 @@ const deployMeteorApp = async () => {
   const meteorSettingsArg = meteorSettingsVar ? `-e METEOR_SETTINGS='${meteorSettingsVar}'` : '';
   const rootUrl = !didPassParam('ROOT_URL') ? '-e ROOT_URL=http://localhost.com' : '';
   const deployCommand = new Command(`cd .meteor/local/builds && now -e PORT=3000 ${mongoUrl} ${rootUrl} ${args} ${meteorSettingsArg}`);
-  const stdOut = await deployCommand.run();
-  const deployedAppUrl = stdOut.out.toString();
+  await deployCommand.run();
   spinner.succeed(message);
-  return deployedAppUrl;
+};
+
+const getDeploymentUrl = async () => {
+  logger('getting deployment url...');
+  const now = nowClient();
+  let deployments;
+  try {
+    deployments = await now.getDeployments();
+  } catch (err) {
+    console.error(err);
+  }
+  // get latest deployment url from the list
+  const sortedDeployments = _.sortBy(deployments, 'created');
+  return sortedDeployments[sortedDeployments.length - 1];
 };
 
 const cleanup = async () => {
@@ -103,9 +117,10 @@ const main = async () => {
   try {
     await buildMeteorApp();
     await prepareForUpload();
-    const appUrl = await deployMeteorApp();
+    await deployMeteorApp();
+    const deployment = await getDeploymentUrl();
     await cleanup();
-    spinner.succeed(`meteor app deployed to ${appUrl.split(',')[0]}`);
+    spinner.succeed(`meteor app deployed to ${deployment.url}`);
   } catch (e) {
     spinner.fail();
     console.error(e); // eslint-disable-line no-console

--- a/src/command.js
+++ b/src/command.js
@@ -19,7 +19,7 @@ export default class Command {
   run() {
     logger(`running command: ${this.command}`);
     return new Promise((resolve) => {
-      this.spawner.spawn(this.command).then(function () {
+      this.spawner.spawn(this.command).then(() => {
         resolve(this.data);
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2736,7 +2736,7 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,13 +180,7 @@ async@^1.3.0, async@^1.4.0, async@^1.4.2, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.1.4.tgz#2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4"
-  dependencies:
-    lodash "^4.14.0"
-
-async@^2.1.5:
+async@^2.1.4, async@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/async/-/async-2.1.5.tgz#e587c68580994ac67fc56ff86d3ac56bdbe810bc"
   dependencies:
@@ -2742,7 +2736,7 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2981,6 +2975,13 @@ normalize-package-data@^2.3.2:
 normalize-path@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.0.1.tgz#47886ac1662760d4261b7d979d241709d3ce3f7a"
+
+now-client@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/now-client/-/now-client-0.7.0.tgz#0f11d87487733bbc6a09d6dc5bc1dde93d032af4"
+  dependencies:
+    request "^2.76.0"
+    request-promise-native "^1.0.3"
 
 npmlog@^4.0.1:
   version "4.0.2"
@@ -3389,7 +3390,20 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.55.0, request@^2.79.0:
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise-native@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.3.tgz#9cb2b2f69f137e4acf35116a08a441cbfd0c0134"
+  dependencies:
+    request-promise-core "1.1.1"
+    stealthy-require "^1.0.0"
+
+request@^2.55.0, request@^2.76.0, request@^2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -3623,6 +3637,10 @@ sshpk@^1.7.0:
     jodid25519 "^1.0.0"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+stealthy-require@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.0.0.tgz#1a8ed8fc19a8b56268f76f5a1a3e3832b0c26200"
 
 stream-browserify@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Fixes process of how we obtain the deployment url. Previously we relied on the `now-cli` package to return the appropriate url when its done with its process however this method was not reliable.

The solution was to use ZEIT's [https://github.com/zeit/now-client](https://github.com/zeit/now-client) package which was designed for this purpose.

Under the hood, it uses the local ~/.now.json file for credentials and exposes a number of APIs for the `now` deployment service. The one we are interested in is `now.getDeployments()` which returns a list of all deployments. Once received, simply grabbing the latest deployment will return the appropriate URL to show the user.

This PR fixes https://github.com/jkrup/meteor-now/issues/34