### PR TITLE
No split

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Finally you should have a `production.settings.json` in your project directory i
 ![METEOR-NOW](assets/zeit-meteor.png "METEOR-NOW")
 `meteor-now` use ZEITs [▲now](https://zeit.co/now) service to deploy the Meteor app in a container. Please refer to their [documentation and support](https://github.com/zeit/) for hosting related details.
 
+# Bundle Splitting
+The `now` free tier has a limitation of 1mb per file. As a workaround, we split the final bundle into pieces prior to uploading. If you are on a paid plan, you can turn this off by passing the `--nosplit` flag like so `meteor-now --nosplit`.
+
 # Additional Info
 ## Full deploy with MongoDB
 `meteor-now` lets you to deploy your Meteor app with a MongoDB included similar to how `meteor deploy` used to work. **This method is not intended for production deployments**. In order to achieve this, we bundle your Meteor app and MongoDB into a a single Dockerfile and we instruct your app to connect to the local MongoDB instance. The Dockerfile gets built in the cloud by `now` and once it's ready, the Meteor app will spin up and connect to the MongoDB instance running locally in that docker container.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-now",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "description": "Deploy meteor apps with one command using now.sh (https://zeit.co/now)",
   "repository": "https://github.com/jkrup/meteor-now",
   "author": "Justin Krup",

--- a/src/api/__tests__/args.js
+++ b/src/api/__tests__/args.js
@@ -147,7 +147,6 @@ describe('args test', () => {
     ]);
   });
 
-
   test('it should ignore certain flags', () => {
     process.argv = [
       'node',

--- a/src/api/__tests__/args.js
+++ b/src/api/__tests__/args.js
@@ -146,4 +146,24 @@ describe('args test', () => {
       'abc.com',
     ]);
   });
+
+
+  test('it should ignore certain flags', () => {
+    process.argv = [
+      'node',
+      '-e',
+      'MONGO_URL=mongodb://127.0.0.1:27017',
+      '-e',
+      'ROOT_URL=http://localhost:3000',
+      '-e',
+      'MY_SPECIAL_VAR=cats',
+      '-e',
+      'SECRET=litter',
+      '--deps',
+      'abc',
+      '--nosplit',
+    ];
+    const remainingVariables = getRemainingVariables();
+    expect(remainingVariables).toEqual([['-e', 'MY_SPECIAL_VAR=cats'], ['-e', 'SECRET=litter']]);
+  });
 });

--- a/src/api/constants.js
+++ b/src/api/constants.js
@@ -12,5 +12,5 @@ export const homePath = os.homedir();
 export const meteorNowBuildPath = `${homePath}/.meteor-now/build`;
 export const tarFileName = `${projectName}.tar.gz`;
 export const ignoreVarsArray = ['MONGO_URL', 'ROOT_URL', 'METEOR_SETTINGS', 'PORT'];
-export const ignoreOptionsArray = ['deps', '_', '$0', 'help', 'version'];
+export const ignoreOptionsArray = ['deps', '_', '$0', 'help', 'version', 'nosplit'];
 export const logPrefix = '[METEOR-NOW] - ';

--- a/src/api/docker.js
+++ b/src/api/docker.js
@@ -47,7 +47,7 @@ VOLUME ["/data/db"]`
 LABEL name="${projectName}"
 COPY . /usr/src/app/
 WORKDIR /usr/src/app
-RUN cat *sf-part* > bundle.tar.gz
+${!getArg('nosplit') ? 'RUN cat *sf-part* > bundle.tar.gz' : ''}
 RUN tar -xzf bundle.tar.gz
 WORKDIR bundle/programs/server
 RUN npm install

--- a/src/api/files.js
+++ b/src/api/files.js
@@ -3,23 +3,32 @@ import splitFile from 'split-file';
 import del from 'del';
 import logger from './logger';
 import { meteorNowBuildPath, tarFileName } from './constants';
+import { getArg } from './args';
 
 const encoding = 'utf8';
 
 export const readFile = path => fs.readFileSync(path, encoding);
 export const writeFile = (path, data) => fs.writeFileSync(path, data, encoding);
-
 export const deletePath = path => del(path, { force: true });
+export const renameFile = (oldPath, newPath) => fs.renameSync(oldPath, newPath);
 
 // split meteor bundle into pieces
-export const splitBuild = async () => {
-  logger.debug('splitting bundle');
+export const prepareBundle = async () => {
+  const bundlePath = `${meteorNowBuildPath}/${tarFileName}`;
   try {
-    await splitFile.splitFileBySize(`${meteorNowBuildPath}/${tarFileName}`, 999999);
+    if (getArg('nosplit')) {
+      renameFile(bundlePath, `${meteorNowBuildPath}/bundle.tar.gz`);
+    } else {
+      logger.debug('splitting bundle');
+      await splitFile.splitFileBySize(
+        `${meteorNowBuildPath}/${tarFileName}`,
+        999999,
+      );
+      await deletePath(bundlePath);
+    }
   } catch (e) {
     logger.error(e);
   }
-  await deletePath(`${meteorNowBuildPath}/${tarFileName}`);
 };
 
 export const clearBuildFolder = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
 import { buildMeteorApp } from './api/meteor';
 import { prepareDockerConfig } from './api/docker';
-import { clearBuildFolder, splitBuild } from './api/files';
+import { clearBuildFolder, prepareBundle } from './api/files';
 import { deploy } from './api/now';
 
 const main = async () => {
   await clearBuildFolder();
   await buildMeteorApp();
   await prepareDockerConfig();
-  await splitBuild();
+  await prepareBundle();
   await deploy();
 };
 


### PR DESCRIPTION
Adds a `--nosplit` feature to avoid bundling the build file. To use just call `meteor-now --nosplit`.