### PR TITLE
Surface now.sh errors; adjustments for env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm*
 build
 .DS_Store
+.nvmrc

--- a/src/api/args.js
+++ b/src/api/args.js
@@ -17,7 +17,7 @@ export const getEnvironmentVariables = () => {
     const envArray = e.split('=');
     return {
       name: envArray[0],
-      value: envArray[1],
+      value: envArray.length > 2 ? ["\"", envArray.slice(1, envArray.length).join("="), "\""].join("") : envArray[1],
     };
   });
 };

--- a/src/api/args.js
+++ b/src/api/args.js
@@ -15,9 +15,13 @@ export const getEnvironmentVariables = () => {
   const argsArray = args instanceof Array ? args : [args];
   return argsArray.map((e) => {
     const envArray = e.split('=');
+    let val = envArray[1];
+    if (envArray.length > 2) {
+      val = ['"', envArray.slice(1, envArray.length).join('='), '"'].join('');
+    }
     return {
       name: envArray[0],
-      value: envArray.length > 2 ? ["\"", envArray.slice(1, envArray.length).join("="), "\""].join("") : envArray[1],
+      value: val,
     };
   });
 };
@@ -48,6 +52,7 @@ export const getRemainingVariables = (environmentVariables = getEnvironmentVaria
 // get remaining options that user has passsed to meteor-now
 export const getRemainingOptions = () => {
   const args = getArgs();
+  console.log('args are ', args);
   return (
     Object.entries(args)
       // filter out specified list of options

--- a/src/api/now.js
+++ b/src/api/now.js
@@ -35,6 +35,8 @@ export const constructNowOptions = async () => {
     ...remainingVariables,
   ];
 
+  console.log("now options are ", options);
+
   // construct the METEOR_SETTINGS, first by checking if user passed
   // -e METEOR_SETTINGS='{ "foo": "bar" }' option to meteor-now
   let meteorSettings = getEnvironmentVariable('METEOR_SETTINGS', environmentVariables);
@@ -70,6 +72,6 @@ export const deploy = async () => {
       logger.succeed();
     }
   } catch (e) {
-    logger.error('Something went wrong with now');
+    logger.error('Something went wrong with now: ' + JSON.stringify(e));
   }
 };

--- a/src/api/now.js
+++ b/src/api/now.js
@@ -34,9 +34,6 @@ export const constructNowOptions = async () => {
     ['-e', `MONGO_URL=${mongoUrl}`],
     ...remainingVariables,
   ];
-
-  console.log("now options are ", options);
-
   // construct the METEOR_SETTINGS, first by checking if user passed
   // -e METEOR_SETTINGS='{ "foo": "bar" }' option to meteor-now
   let meteorSettings = getEnvironmentVariable('METEOR_SETTINGS', environmentVariables);

--- a/src/api/now.js
+++ b/src/api/now.js
@@ -69,6 +69,6 @@ export const deploy = async () => {
       logger.succeed();
     }
   } catch (e) {
-    logger.error('Something went wrong with now: ' + JSON.stringify(e));
+    logger.error('Something went wrong with now', e);
   }
 };


### PR DESCRIPTION
I have a `MONGO_URL` variable that has a `?ssl=true&...` in it's querystring -- I made some changes to ensure these get passed correctly to now during deployment.

I also surfaced the exception to the logger when now fails. (This helped me find a missing (and required) `production.settings.json` file.