### PR TITLE
feat(docker): add docker-image flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Because now enforces SSL, you may experience some issues with 3rd party resource
 ### I deployed my free app but it's failing to connect to MongoDB
 If you're deploying with an included MongoDB, we've observed that sometimes MongoDB takes a while to start. In this case, Meteor complains that it can't connect to MongoDB. Give it a few more minutes and your app should start. Make sure to refresh the page.
 
+### I want to use a different docker image
+The default docker images are `nodesource/jessie:0.10.43` for Meteor < 1.4 and `node:carbon` for >= 1.4.
+If you want to use a different image, use the `--docker-image` flag.
+
 ### My app requires XX can I use my own Dockerfile?
 We're currently support passing a `--deps 'depName1,depName2'` flag so that applications that rely on things like imagemagick are able to work. We are also looking into the ability to specify your own Dockerfile in the case that you require even more customization.
 

--- a/src/api/docker.js
+++ b/src/api/docker.js
@@ -10,7 +10,7 @@ export const getDockerImage = () => {
   if (dockerImage) return dockerImage;
   if (parseInt(getMicroVersion(), 10) < 4) return 'nodesource/jessie:0.10.43';
   return 'node:carbon';
-}
+};
 
 // check if mongo url was passed as a env var
 export const shouldIncludeMongo = () => !getEnvironmentVariable('MONGO_URL');

--- a/src/api/docker.js
+++ b/src/api/docker.js
@@ -5,8 +5,12 @@ import { getMicroVersion } from './meteor';
 import { getEnvironmentVariable, getArg } from './args';
 
 // get docker image version
-export const getDockerImage = () =>
-  (parseInt(getMicroVersion(), 10) < 4 ? 'nodesource/jessie:0.10.43' : 'node:carbon');
+export const getDockerImage = () => {
+  const dockerImage = getArg('docker-image');
+  if (dockerImage) return dockerImage;
+  if (parseInt(getMicroVersion(), 10) < 4) return 'nodesource/jessie:0.10.43';
+  return 'node:carbon';
+}
 
 // check if mongo url was passed as a env var
 export const shouldIncludeMongo = () => !getEnvironmentVariable('MONGO_URL');


### PR DESCRIPTION
**Issue:**
Deployments restarted without any error message on now service. this had the effect that the users reconnected every x minutes and the deployment state sets to DEPLOYMENT_ERROR after a while.
**Solution:**
I spent many hours with the now support to find the reason.
Finally we noticed that the node version is different in deployments with the restart issue.
Issue with v8.10.0 and no issue with v8.9.4. Check https://github.com/meteor/meteor/pull/9725 for more details.
I checked the source of meteor-now. The issue is that the docker-image is set to `node:carbon` without specifying the correct version. That means some deployments have v8.9.4 and others v8.10.0.
This pr adds a `--docker-image` flag to specify the docker image. 
It is possible to set it to `node:8.9.4` or other images like `spaceglue:node-8.9.3`.
**Other:**
I think it makes sense to set the default image to `node:8.9.4` instead of `node:carbon`.