### PR TITLE
Allow intermediate container cache functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ora": "^1.3.0",
     "prettier": "^1.7.4",
     "split-file": "^2.1.0",
+    "tar": "^4.4.1",
     "yargs": "^9.0.1"
   },
   "devDependencies": {

--- a/src/api/docker.js
+++ b/src/api/docker.js
@@ -53,14 +53,15 @@ RUN apt-get install -y supervisor
 VOLUME ["/data/db"]`
     : ''}
 LABEL name="${projectName}"
-COPY . /usr/src/app/
-WORKDIR /usr/src/app
+COPY bundle/programs/server/package.json /usr/src/app/bundle/programs/server/package.json
+WORKDIR /usr/src/app/bundle/programs/server
+RUN npm install
+WORKDIR ../../..
+COPY . .
 ${!getArg('nosplit') ? 'RUN cat *sf-part* > bundle.tar.gz' : ''}
 RUN tar -xzf bundle.tar.gz
-WORKDIR bundle/programs/server
-RUN npm install
-WORKDIR ../../
 ${includeMongo ? 'COPY supervisord.conf /etc/supervisor/supervisord.conf' : ''}
+WORKDIR bundle
 EXPOSE 3000
 ${includeMongo ? 'CMD ["supervisord"]' : 'CMD ["node", "main.js"]'}`;
 };

--- a/src/api/files.js
+++ b/src/api/files.js
@@ -1,6 +1,7 @@
 import fs from 'file-system';
 import splitFile from 'split-file';
 import del from 'del';
+import tar from 'tar';
 import logger from './logger';
 import { meteorNowBuildPath, tarFileName } from './constants';
 import { getArg } from './args';
@@ -15,6 +16,11 @@ export const renameFile = (oldPath, newPath) => fs.renameSync(oldPath, newPath);
 // split meteor bundle into pieces
 export const prepareBundle = async () => {
   const bundlePath = `${meteorNowBuildPath}/${tarFileName}`;
+  await tar.x({
+    file: bundlePath,
+    cwd: meteorNowBuildPath,
+  }, ['bundle/programs/server/package.json']);
+
   try {
     if (getArg('nosplit')) {
       renameFile(bundlePath, `${meteorNowBuildPath}/bundle.tar.gz`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,6 +972,10 @@ chokidar@^1.7.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
+chownr@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+
 ci-info@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.1.tgz#47b44df118c48d2597b56d342e7e25791060171a"
@@ -1813,6 +1817,12 @@ form-data@~2.1.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+fs-minipass@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
+  dependencies:
+    minipass "^2.2.1"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2919,7 +2929,20 @@ minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.0:
+minipass@^2.2.1, minipass@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.2.4.tgz#03c824d84551ec38a8d1bb5bc350a5a30a354a40"
+  dependencies:
+    safe-buffer "^5.1.1"
+    yallist "^3.0.0"
+
+minizlib@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.1.0.tgz#11e13658ce46bc3a70a267aac58359d1e0c29ceb"
+  dependencies:
+    minipass "^2.2.1"
+
+"mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -3906,6 +3929,18 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+tar@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.1.tgz#b25d5a8470c976fd7a9a8a350f42c59e9fa81749"
+  dependencies:
+    chownr "^1.0.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.2.4"
+    minizlib "^1.1.0"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.1"
+    yallist "^3.0.2"
+
 test-exclude@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.1.tgz#4d84964b0966b0087ecc334a2ce002d3d9341e26"
@@ -4230,6 +4265,10 @@ y18n@^3.2.1:
 yallist@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.0.0.tgz#306c543835f09ee1a4cb23b7bce9ab341c91cdd4"
+
+yallist@^3.0.0, yallist@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
 
 yargs-parser@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Ziet/Now caches the image on the machine that runs them, but each deployment can end up on a different machine. So unfortunately this is not guaranteed to speed up deploys, however it should not slow them down by very much, and presumably if you are deploying many times to the same region you may get the same machine to build the image. 
This at least gives a chance of speeding up deploys so I think if it doesn't cause any issues we should merge it in. 
There are also plans by now in the future to support shared image caching- so when that happens we will already be there.