### PR TITLE
feat(docker): add custom healthcheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-now",
-  "version": "0.6.2",
+  "version": "0.6.1",
   "description": "Deploy meteor apps with one command using now.sh (https://zeit.co/now)",
   "repository": "https://github.com/jkrup/meteor-now",
   "author": "Justin Krup",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meteor-now",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Deploy meteor apps with one command using now.sh (https://zeit.co/now)",
   "repository": "https://github.com/jkrup/meteor-now",
   "author": "Justin Krup",

--- a/src/api/docker.js
+++ b/src/api/docker.js
@@ -103,7 +103,7 @@ HEALTHCHECK \
   --interval=${getHealthcheckInterval()} \
   --timeout=${getEnvironmentVariable('HEALTHCHECK_TIMEOUT') || '10s'} \
   --retries=${getHealthcheckRetries()} \
-  CMD node healthcheck.js`;
+  CMD node /usr/src/app/healthcheck.js`;
 };
 
 // construct the supervisord contents

--- a/src/api/docker.js
+++ b/src/api/docker.js
@@ -63,7 +63,7 @@ WORKDIR ../../
 ${includeMongo ? 'COPY supervisord.conf /etc/supervisor/supervisord.conf' : ''}
 EXPOSE 3000
 ${includeMongo ? 'CMD ["supervisord"]' : 'CMD ["node", "main.js"]'}
-HEALTHCHECK --interval=1m --timeout=5s CMD curl -f http://localhost:3000/ || exit 1`;
+HEALTHCHECK --interval=20s --timeout=8s --retries=3 CMD curl -f http://localhost:3000/ || exit 1`;
 };
 
 // construct the supervisord contents

--- a/src/api/docker.js
+++ b/src/api/docker.js
@@ -57,7 +57,7 @@ const getHealthcheckFileContents = () => {
 const options = {  
   host: 'localhost',
   port: 3000,
-  path: ${path},
+  path: '${path}',
   timeout : ${timeout}
 };
 
@@ -69,7 +69,8 @@ request.on('error', err => {
   process.exit(1);
 });
 
-request.end();`;
+request.end();
+`;
 };
 
 // construct the Dockerfile contents

--- a/src/api/docker.js
+++ b/src/api/docker.js
@@ -63,7 +63,7 @@ WORKDIR ../../
 ${includeMongo ? 'COPY supervisord.conf /etc/supervisor/supervisord.conf' : ''}
 EXPOSE 3000
 ${includeMongo ? 'CMD ["supervisord"]' : 'CMD ["node", "main.js"]'}
-HEALTHCHECK --interval=1m --timeout=5s --start-period=10s CMD curl -f http://localhost:3000/ || exit 1`;
+HEALTHCHECK --interval=1m --timeout=5s CMD curl -f http://localhost:3000/ || exit 1`;
 };
 
 // construct the supervisord contents

--- a/src/api/docker.js
+++ b/src/api/docker.js
@@ -62,7 +62,8 @@ RUN npm install
 WORKDIR ../../
 ${includeMongo ? 'COPY supervisord.conf /etc/supervisor/supervisord.conf' : ''}
 EXPOSE 3000
-${includeMongo ? 'CMD ["supervisord"]' : 'CMD ["node", "main.js"]'}`;
+${includeMongo ? 'CMD ["supervisord"]' : 'CMD ["node", "main.js"]'}
+HEALTHCHECK --interval=1m --timeout=5s --start-period=10s CMD curl -f http://localhost:3000/ || exit 1`;
 };
 
 // construct the supervisord contents

--- a/src/api/docker.js
+++ b/src/api/docker.js
@@ -100,9 +100,9 @@ ${includeMongo ? 'COPY supervisord.conf /etc/supervisor/supervisord.conf' : ''}
 EXPOSE 3000
 ${includeMongo ? 'CMD ["supervisord"]' : 'CMD ["node", "main.js"]'}
 HEALTHCHECK \
-  --interval=${getHealthcheckInterval} \
+  --interval=${getHealthcheckInterval()} \
   --timeout=${getEnvironmentVariable('HEALTHCHECK_TIMEOUT') || '10s'} \
-  --retries=${getHealthcheckRetries} \
+  --retries=${getHealthcheckRetries()} \
   CMD node healthcheck.js`;
 };
 


### PR DESCRIPTION
BLOCKED!
I am waiting for zeit to update the docker healthchecks because right now they doesn't respect the container health status and have different docker versions on their nodes.
This should be done in the next days.

**Issue:**
`now` has a simple docker healthcheck which only checks for open tcp port.
it doesn't check for http, which means, that the node process could be crashed or in a loop without triggering a docker recovery.
you can simulate it by calling a simple `process.exit()` on Meteor server side with the result, that the page has an infinite loader.

**Solution:**
I added a custom docker [healthcheck](https://docs.docker.com/engine/reference/builder/#healthcheck) which request the Meteor server. Usually a simple http request with a timeout should be enough.
It will set the status of the container to unhealthy which will force a recovery on now.

The following envs are supported:
`HEALTHCHECK_PATH` to set a custom path like `/health`. This is useful to add custom health logic.
`HEALTHCHECK_TIMEOUT` to set a http timeout
`HEALTHCHECK_INTERVAL` to set the interval of the checks
`HEALTHCHECK_RETRIES` to set the number of retries before the container is set to unhealthy.

**ToDo:**
A documentation is missing for this new feature. 