### PR TITLE
fix(now): fix flatten remaining options

### DIFF
--- a/src/api/now.js
+++ b/src/api/now.js
@@ -49,7 +49,7 @@ export const constructNowOptions = async () => {
   // get any remaining custom flags passed in by user
   const remainingOptions = getRemainingOptions();
   if (remainingOptions) {
-    options.push(remainingOptions);
+    options.push(flattenOptions(remainingOptions));
   }
 
   return options;


### PR DESCRIPTION
Issue:
Options with one parameter are not processed by now process.
See https://github.com/jkrup/meteor-now/issues/107
Options are not flattened. This is not an issue for options without a parameter like `--public`.

Solution:
flatten options.

Test:
Try to use a option like `--token xzy` or `--regions bru`.

