### PR TITLE
feat(mongodb): update mongodb to 3.6 in Dockerfile

### DIFF
--- a/src/api/docker.js
+++ b/src/api/docker.js
@@ -47,8 +47,10 @@ export const getDockerfileContents = async () => {
   return `FROM ${dockerImage}
 ${deps ? getDependencyInstallScripts(deps) : ''}
 ${includeMongo
-    ? `RUN apt-get update
-RUN apt-get install -y mongodb
+    ? `RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+RUN echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.6 main" | tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+RUN apt-get update
+RUN apt-get install -y mongodb-org
 RUN apt-get install -y supervisor
 VOLUME ["/data/db"]`
     : ''}


### PR DESCRIPTION
See issue https://github.com/jkrup/meteor-now/issues/110

I updated MongoDB to 3.6 in the Dockerfile. 
See installation guide: https://docs.mongodb.com/manual/tutorial/install-mongodb-on-debian/